### PR TITLE
Fix average wind direction widgets

### DIFF
--- a/freeboard/floating.zul
+++ b/freeboard/floating.zul
@@ -46,6 +46,7 @@
 <?script src="./js/chartplotter.js" ?>
 <?script src="./js/tween-min.js"?>
 <?script src="./js/steelseries.js"?>
+<?script src="./js/vectorArray.js"?>
 
 
 <zk>

--- a/freeboard/js/vectorArray.js
+++ b/freeboard/js/vectorArray.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Philip J Freeman <elektron@halo.nu>
+ *
+ * This file is part of FreeBoard. (http://www.42.co.nz/freeboard)
+ *
+ *  FreeBoard is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ 
+ *  FreeBoard is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ 
+ *  You should have received a copy of the GNU General Public License
+ *  along with FreeBoard.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * vectorArray is an object definition to track changing vectors of
+ * wind speed and direction. All directional angles should be given
+ * in degrees (0 =< d < 360.)
+ *
+ * Usage Example:
+ *
+ * var windHistory = new vectorArray();
+ *
+ * while (...) {
+ *   windHistory.addVector( [windSpeed, directionDegrees] )
+ * }
+ *
+ * vectorAverage = windHistory.getVectorAverage
+ * console.log('windSpeed:'+vectorAverage[0]+' directionDegrees:'+vectorAverage[1]);
+ *
+ */
+
+function vectorArray() {
+    this.maxElements = 15;
+    this.vectorArray = [];
+    this.pos = 0;
+
+    this.addVector = function(vector) {
+        this.vectorArray[this.pos] = vector;
+        this.pos++;
+        if (this.pos >= this.maxElements)
+            this.pos = 0;
+    };
+
+    this.getVectorLast = function() {
+        if (this.pos == 0) {
+	    if (this.vectorArray.length == 0) {
+		return [null,null];
+	    } else {
+	        return this.vectorArray[this.vectorArray.length-1];
+	    }
+	} else {
+	    return this.vectorArray[this.pos-1];
+	}
+    };
+
+    this.getVectorAverage = function() {
+        var count = 0;
+        var totX = 0;
+        var totY = 0;
+        for (var i = 0; i < this.vectorArray.length; i++) {
+            if (this.vectorArray[i] != null) {
+                count++;
+                var spd = this.vectorArray[i][0];
+                var dir = this.vectorArray[i][1];
+                var dirRad = dir*(Math.PI / 180);
+                totX += spd*Math.cos(dirRad)
+                totY += spd*Math.sin(dirRad)
+            }
+        }
+        if (count == 0) {
+            return [null, null];
+        }
+        avgX = totX/count;
+        avgY = totY/count;
+
+        var avgSpd = Math.sqrt(Math.pow(avgX,2)+Math.pow(avgY,2));
+        var avgDir = (Math.atan2(avgY, avgX)/(Math.PI / 180));
+        if (avgDir < 0) {
+            avgDir +=360;
+        }
+
+        //console.log( 'vectorAvg('+vectors+') = '+[avgSpd, avgDir] );
+        return [avgSpd, avgDir];
+    };
+}

--- a/freeboard/js/wind2.js
+++ b/freeboard/js/wind2.js
@@ -16,13 +16,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with FreeBoard.  If not, see <http://www.gnu.org/licenses/>.
  */
-//var  lcdWindTrue, radialWindDirTrue
-var avgArrayA = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-    0.0, 0.0, 0.0];
-var avgPosA = 0;
-var avgArrayT = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-    0.0, 0.0, 0.0];
-var avgPosT = 0;
+var wind2VectorArrayApparent = new vectorArray();
+var wind2VectorArrayTrue = new vectorArray();
 
 var width = 400;
 
@@ -82,19 +77,20 @@ function Wind2() {
             }
 
             // make average
-            avgArrayA[avgPosA] = c;
-            avgPosA = avgPosA + 1;
-            if (avgPosA >= avgArrayA.length)
-                avgPosA = 0;
-            var v = 0;
-            for (var i = 0; i < avgArrayA.length; i++) {
-                v = v + avgArrayA[i];
-            }
-            if (c > 180) {
-                radialWindDirApp
-                        .setValueAnimatedAverage(-(360 - (v / avgArrayA.length)));
+            if (navObj.WSA) {
+                if (c < 0) {
+                    c += 360;
+                }
+                wind2VectorArrayApparent.addVector([navObj.WSA, c]);
             } else {
-                radialWindDirApp.setValueAnimatedAverage(v / avgArrayA.length);
+                wind2VectorArrayApparent.addVector(null);
+            }
+            avgVector = wind2VectorArrayApparent.getVectorAverage();
+            if (avgVector[1] > 180) {
+                radialWindDirApp
+                        .setValueAnimatedAverage(-(360 - avgVector[1]));
+            } else {
+                radialWindDirApp.setValueAnimatedAverage(avgVector[1]);
             }
 
             c = null;
@@ -107,22 +103,21 @@ function Wind2() {
                 radialWindDirTrue.setValueAnimatedLatest(0.0);
 
             // make average
-            avgArrayT[avgPosT] = c;
-            avgPosT = avgPosT + 1;
-            if (avgPosT >= avgArrayT.length)
-                avgPosT = 0;
-            var v = 0.0;
-            for (var i = 0; i < avgArrayT.length; i++) {
-                v = v + avgArrayT[i];
+            if (navObj.WST) {
+                if (c < 0) {
+                    c += 360;
+                }
+                wind2VectorArrayTrue.addVector([navObj.WST, c]);
+            } else {
+                wind2VectorArrayTrue.addVector(null);
             }
-            if (v > 0.0)
-                radialWindDirTrue.setValueAnimatedAverage(v / avgArrayT.length);
+            avgVector = wind2VectorArrayTrue.getVectorAverage();
+            if (avgVector[1]  > 0.0)
+                radialWindDirTrue.setValueAnimatedAverage(avgVector[1]);
             else
                 radialWindDirTrue.setValueAnimatedAverage(0.0);
         }
         c = null;
-
-        data = null;
     };
 }
 

--- a/freeboard/js/windLogg.js
+++ b/freeboard/js/windLogg.js
@@ -16,13 +16,10 @@
  *  You should have received a copy of the GNU General Public License
  *  along with FreeBoard.  If not, see <http://www.gnu.org/licenses/>.
  */
-//var  lcdWindTrue, radialWindDirTrue
-var avgArrayA = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0 ];
-var avgPosA = 0;
-var avgArrayT = [ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-		0.0, 0.0, 0.0 ];
-var avgPosT = 0;
+
+// wind vector averaging objects
+var windLoggVectorArrayApparent = new vectorArray();
+var windLoggVectorArrayTrue = new vectorArray();
 
 function Wind2() {
 	this.onmessage = function(navObj) {
@@ -48,21 +45,14 @@ function Wind2() {
 			}
 
 			// make average
-			avgArrayA[avgPosA] = c;
-			avgPosA = avgPosA + 1;
-			if (avgPosA >= avgArrayA.length)
-				avgPosA = 0;
-			var v = 0;
-			for ( var i = 0; i < avgArrayA.length; i++) {
-				v = v + avgArrayA[i];
-			}
-			if (c > 180) {
+			windLoggVectorArrayApparent.addVector([navObj.WSA, c]);
+			avgVector = windLoggVectorArrayApparent.getVectorAverage();
+			if (avgVector[1] > 180) {
 				radialWindDirApp
-						.setValueAnimatedAverage(-(360 - (v / avgArrayA.length)));
+						.setValueAnimatedAverage(-(360 - avgVector[1]));
 			} else {
-				radialWindDirApp.setValueAnimatedAverage(v / avgArrayA.length);
+				radialWindDirApp.setValueAnimatedAverage(avgVector[1]);
 			}
-
 			c = null;
 		}
 		if (navObj.WDT) {
@@ -74,19 +64,12 @@ function Wind2() {
 				radialWindDirTrue.setValueAnimatedLatest(0.0);
 
 			// make average
-			avgArrayT[avgPosT] = c;
-			avgPosT = avgPosT + 1;
-			if (avgPosT >= avgArrayT.length)
-				avgPosT = 0;
-			var v = 0.0;
-			for ( var i = 0; i < avgArrayT.length; i++) {
-				v = v + avgArrayT[i];
-			}
-			if (v > 0.0)
-				radialWindDirTrue.setValueAnimatedAverage(v / avgArrayT.length);
+			windLoggVectorArrayTrue.addVector([navObj.WST, c]);
+			avgVector = windLoggVectorArrayTrue.getVectorAverage();
+			if ( avgVector[1] > 0.0)
+				radialWindDirTrue.setValueAnimatedAverage(avgVector[1]);
 			else
 				radialWindDirTrue.setValueAnimatedAverage(0.0);
-
 			c = null;
 		}
 		if (navObj.SOG) {
@@ -110,7 +93,6 @@ function Wind2() {
 			}
 			c = null;
 		}
-		data = null;
 	};
 }
 

--- a/freeboard/sail.zul
+++ b/freeboard/sail.zul
@@ -42,6 +42,7 @@
 <?script src="./js/layers.js" ?>
 <?script src="./js/tween-min.js"?>
 <?script src="./js/steelseries.js"?>
+<?script src="./js/vectorArray.js"?>
 
 <!--
 <?script src="./js/sparkline.js"?>

--- a/freeboard/windLogg.zul
+++ b/freeboard/windLogg.zul
@@ -42,6 +42,7 @@
 <?script src="./js/layers.js" ?>
 <?script src="./js/tween-min.js"?>
 <?script src="./js/steelseries.js"?>
+<?script src="./js/vectorArray.js"?>
 <zk>
    <script type="text/javascript" src="./js/windLogg.js" />
    <style>


### PR DESCRIPTION
when the wind direction passes through 0 degrees, averages from a ring buffer of past values don't make sense. This was causing the average wind direction pointer to swing wildly around. for example, say we have the values [3,4,5] an average of 4 makes sense in degrees. When we swing just a handful of degrees to port [4,5,351] an average of 120 degrees does not make sense.

This pull request changes the logic of the average calculation by resetting the ring buffer of values every time we pass through 0 degrees to one side or the other. The buffer then begins accumulating values again and builds an average for only the values on the new side.

While this solution is not technically correct, It sure looks a lot better to me.

I've also fixed an unrelated bug where toggling the toggleWind widget would make it display NaN in the current value box in the gauge.

fixes #28 