### PR TITLE
 Fix Boat/Home settings in ConfigViewModel

### DIFF
--- a/src/main/java/nz/co/fortytwo/freeboard/zk/ConfigViewModel.java
+++ b/src/main/java/nz/co/fortytwo/freeboard/zk/ConfigViewModel.java
@@ -240,7 +240,7 @@ public class ConfigViewModel extends SelectorComposer<Window> {
         layers.append("\tlayers = L.control.layers(baseLayers, overlays).addTo(map);\n");
         layers.append("\t};\n");
         String layersStr = layers.toString();
-        if (!useHomeChoice) {
+        if (useHomeChoice) {
             // we parse out all refs to the subdomains
             // remove {s}.
             layersStr = StringUtils.remove(layersStr, "{s}.");


### PR DESCRIPTION
    
    In Boat mode, the entries in Layers.js appear as:
    
        var _1552_1 = L.tileLayer("http://{s}.{server}:8080/mapcache/11552_1/{z}/{x}/{y}.png", {
                server: host,
                subdomains: 'abcd',
                attribution: '11552_1 NEUSE RIVER AND UPPER PART OF BAY RIVER ',
                minZoom: 9,
                maxNativeZoom: 16,
                maxZoom: 19,
                tms: true
                }).addTo(map);
    
    In Home mode, the {s} and subdomains are omitted.